### PR TITLE
Update import to support wagtail 3.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,13 +31,13 @@ repos:
         exclude: CHANGELOG.md
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.6.0
+    rev: v2.6.2
     hooks:
       - id: prettier
         files: '^docs/.*\.mdx?$'
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.2.0
     hooks:
       - id: trailing-whitespace
       - id: check-merge-conflict
@@ -45,7 +45,7 @@ repos:
       - id: check-toml
 
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
         exclude: ^tests/codegen/snapshots/python/

--- a/strawberry_wagtail/schema.py
+++ b/strawberry_wagtail/schema.py
@@ -2,8 +2,13 @@ import re
 import types
 from typing import Iterable, List, Optional, Type
 
-from wagtail.core.fields import StreamField
-from wagtail.core.models import Page
+
+try:
+    from wagtail.fields import StreamField
+    from wagtail.models import Page
+except ImportError:
+    from wagtail.core.fields import StreamField
+    from wagtail.core.models import Page
 
 from django.db.models.fields import Field
 
@@ -23,7 +28,11 @@ def to_snake_case(name: str) -> str:
 
 def _register_fields():
     from strawberry_django.fields.types import field_type_map
-    from wagtail.core.fields import RichTextField
+
+    try:
+        from wagtail.fields import RichTextField
+    except ImportError:
+        from wagtail.core.fields import RichTextField
 
     field_type_map[RichTextField] = HTML
 

--- a/strawberry_wagtail/stream_field.py
+++ b/strawberry_wagtail/stream_field.py
@@ -1,9 +1,16 @@
 import dataclasses
 from typing import Any, Callable, List, Optional, Type
 
-from wagtail.core.blocks.field_block import CharBlock, FieldBlock, RichTextBlock
-from wagtail.core.blocks.stream_block import StreamBlock
-from wagtail.core.fields import StreamField
+
+try:
+    from wagtail.blocks.field_block import CharBlock, FieldBlock, RichTextBlock
+    from wagtail.blocks.stream_block import StreamBlock
+    from wagtail.fields import StreamField
+except ImportError:
+    from wagtail.core.blocks.field_block import CharBlock, FieldBlock, RichTextBlock
+    from wagtail.core.blocks.stream_block import StreamBlock
+    from wagtail.core.fields import StreamField
+
 from wagtail.images.blocks import ImageChooserBlock
 
 import strawberry

--- a/strawberry_wagtail/views.py
+++ b/strawberry_wagtail/views.py
@@ -1,6 +1,10 @@
 from functools import cached_property
 
-from wagtail.core.models import Page
+
+try:
+    from wagtail.models import Page
+except ImportError:
+    from wagtail.core.models import Page
 
 from django.apps import apps
 


### PR DESCRIPTION
This update imports to support wagtail 3.0
How can I run tests locally 🤔 ?
Also, I ran `pre-commit autoupdate` because I ran into this error caused by outdated black https://stackoverflow.com/questions/71673404/importerror-cannot-import-name-unicodefun-from-click 